### PR TITLE
fix: Compatible with 2D array generation

### DIFF
--- a/example/user.api
+++ b/example/user.api
@@ -30,6 +30,7 @@ type (
         Birthday string `json:"birthday"`
         Description string `json:"description"`
         Tag []string `json:"tag"`
+        Tags [][]string `json:"tags"`
     }
 
     UserSearchReq {

--- a/example/user.json
+++ b/example/user.json
@@ -36,7 +36,6 @@
             }
           }
         ],
-        "requestBody": {},
         "tags": [
           "user-api"
         ]
@@ -63,7 +62,6 @@
             }
           }
         ],
-        "requestBody": {},
         "tags": [
           "user-api"
         ]
@@ -90,7 +88,6 @@
             "type": "string"
           }
         ],
-        "requestBody": {},
         "tags": [
           "user-api"
         ]
@@ -116,7 +113,6 @@
             "type": "string"
           }
         ],
-        "requestBody": {},
         "tags": [
           "user-api"
         ]
@@ -183,6 +179,15 @@
           "items": {
             "type": "string"
           }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "title": "UserInfoReply",
@@ -191,20 +196,13 @@
         "age",
         "birthday",
         "description",
-        "tag"
+        "tag",
+        "tags"
       ]
     },
     "UserInfoReq": {
       "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      },
-      "title": "UserInfoReq",
-      "required": [
-        "id"
-      ]
+      "title": "UserInfoReq"
     },
     "UserSearchReq": {
       "type": "object",
@@ -227,10 +225,5 @@
       "name": "Authorization",
       "in": "header"
     }
-  },
-  "security": [
-    {
-      "apiKey": []
-    }
-  ]
+  }
 }

--- a/generate/parser.go
+++ b/generate/parser.go
@@ -390,6 +390,17 @@ func schemaOfField(member spec.Member) swaggerSchemaObject {
 			core = schemaCore{Type: "object"}
 		} else if refTypeName == "mapstringstring" {
 			core = schemaCore{Type: "object"}
+		} else if strings.HasPrefix(refTypeName, "[]") {
+			core = schemaCore{Type: "array"}
+
+			tempKind := swaggerMapTypes[strings.Replace(refTypeName, "[]", "", -1)]
+			ftype, format, ok := primitiveSchema(tempKind, refTypeName)
+			if ok {
+				core.Items = &swaggerItemsObject{Type: ftype, Format: format}
+			} else {
+				core.Items = &swaggerItemsObject{Type: ft.String(), Format: "UNKNOWN"}
+			}
+
 		} else {
 			core = schemaCore{
 				Ref: "#/definitions/" + refTypeName,


### PR DESCRIPTION
fix: Compatible with 2D array generation.  for example: tags [][]string

```
        "tags": {
          "type": "array",
          "items": {
            "type": "array",
            "items": {
              "type": "string"
            }
          }
        }
```

fix: 兼容二维数组生成  例如: tag [][]string