### PR TITLE
fix prefix not start with /

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -99,8 +99,10 @@ func applyGenerate(p *plugin.Plugin, host string, basePath string) (*swaggerObje
 func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swaggerPathsObject, requestResponseRefs refMap) {
 	for _, group := range groups {
 		for _, route := range group.Routes {
-
 			path := group.GetAnnotation("prefix") + route.Path
+			if path[0] != '/' {
+				path = "/" + path
+			}
 			parameters := swaggerParametersObject{}
 
 			if countParams(path) > 0 {


### PR DESCRIPTION
# Issue：
定义prefix 不以 / 开始时，生成openapi 2.0文档lint报错

```go
@server(
    prefix: api/v1
    group: user
)
service loopx-api {
    @handler Login
    post /user/login (UserLoginReq) returns (UserInfoReply)
}
```
生成的openapi2.0 
```json
"api/v1/user/login": {
      "post": {
        "operationId": "Login",
        "responses": {
          "200": {
            "description": "A successful response.",
            "schema": {
              "$ref": "#/definitions/UserInfoReply"
            }
          }
        },
        "parameters": [
          {
            "name": "body",
            "in": "body",
            "required": true,
            "schema": {
              "$ref": "#/definitions/UserLoginReq"
            }
          }
        ],
        "tags": [
          "user"
        ]
      }
    },
```