### PR TITLE
fix go validator in api

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -18,6 +18,7 @@ import (
 var strColon = []byte(":")
 
 const (
+	validateKey     = "validate"
 	defaultOption   = "default"
 	stringOption    = "string"
 	optionalOption  = "optional"
@@ -491,6 +492,11 @@ func renderReplyAsDefinition(d swaggerDefinitionsObject, m messageMap, p []spec.
 			*schema.Properties = append(*schema.Properties, kv)
 
 			for _, tag := range member.Tags() {
+				if tag.Key == validateKey {
+					// if you want to define a go-validator in
+					// go-zero api, you should ignore it
+					continue
+				}
 				if len(tag.Options) == 0 {
 					if !contains(schema.Required, tag.Name) && tag.Name != "required" {
 						schema.Required = append(schema.Required, tag.Name)


### PR DESCRIPTION
I found a bug if I use [validator](https://github.com/go-playground/validator) in *.api file. This plugin will generate the illegal swagger file like this.
```go
        // API body
	AddTaskTypeReq {
		SessionId         string `json:"session_id"`
		Name              string `json:"name" validate:"gte=1,lte=64"`
		MaxTaskInQueLimit int64  `json:"max_task_in_que_limit" validate:"min=-1,max=100000"`
		ExtraInfo         string `json:"extra_info,optional"`
	}
```

swagger json
````json
"AddTaskTypeReq": {
      "type": "object",
      "properties": {
        "session_id": {
          "type": "string"
        },
        "name": {
          "type": "string"
        },
        "max_task_in_que_limit": {
          "type": "integer",
          "format": "int64"
        },
        "extra_info": {
          "type": "string"
        }
      },
      "title": "AddTaskTypeReq",
      "required": [
        "session_id",
        "name",
        "gte=1",
        "max_task_in_que_limit",
        "min=-1"
      ]
    }
````
the **gte=1** and **min=-1** in output file is unexpected.
so I create a PR to fix this bug