### PR TITLE
fix(parser.go): 修复validate字段的bug,添加了对form-data的支持

### DIFF
--- a/generate/entities.go
+++ b/generate/entities.go
@@ -137,9 +137,9 @@ type swaggerOperationObject struct {
 	RequestBody *struct {
 		Content swaggerContentObject `json:"content,omitempty"`
 	} `json:"requestBody,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
-	Deprecated bool     `json:"deprecated,omitempty"`
-
+	Tags         []string                            `json:"tags,omitempty"`
+	Deprecated   bool                                `json:"deprecated,omitempty"`
+	Consumes     []string                            `json:"consumes,omitempty"`
 	Security     *[]swaggerSecurityRequirementObject `json:"security,omitempty"`
 	ExternalDocs *swaggerExternalDocumentationObject `json:"externalDocs,omitempty"`
 }

--- a/generate/parser.go
+++ b/generate/parser.go
@@ -18,6 +18,7 @@ import (
 var strColon = []byte(":")
 
 const (
+	validateKey     = "validate"
 	defaultOption   = "default"
 	stringOption    = "string"
 	optionalOption  = "optional"
@@ -390,6 +391,10 @@ func renderStruct(member spec.Member) swaggerParameterObject {
 	sp := swaggerParameterObject{In: "query", Type: ftype, Format: format}
 
 	for _, tag := range member.Tags() {
+		if tag.Key == validateKey {
+			continue
+		}
+
 		sp.Name = tag.Name
 		if len(tag.Options) == 0 {
 			sp.Required = true
@@ -491,6 +496,9 @@ func renderReplyAsDefinition(d swaggerDefinitionsObject, m messageMap, p []spec.
 			*schema.Properties = append(*schema.Properties, kv)
 
 			for _, tag := range member.Tags() {
+				if tag.Key == validateKey {
+					continue
+				}
 				if len(tag.Options) == 0 {
 					if !contains(schema.Required, tag.Name) && tag.Name != "required" {
 						schema.Required = append(schema.Required, tag.Name)

--- a/generate/parser.go
+++ b/generate/parser.go
@@ -242,6 +242,14 @@ func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swagge
 							Required: true,
 							Schema:   &schema,
 						}
+
+						for _, member := range defineStruct.Members {
+							if strings.Contains(member.Tag, "form") {
+								parameter.In = "formData"
+								break
+							}
+						}
+
 						doc := strings.Join(route.RequestType.Documents(), ",")
 						doc = strings.Replace(doc, "//", "", -1)
 
@@ -294,6 +302,15 @@ func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swagge
 						},
 					},
 				},
+			}
+
+			if defineStruct, ok := route.RequestType.(spec.DefineStruct); ok {
+				for _, member := range defineStruct.Members {
+					if strings.Contains(member.Tag, "form") {
+						operationObject.Consumes = []string{"multipart/form-data"}
+						break
+					}
+				}
 			}
 
 			for _, v := range route.Doc {


### PR DESCRIPTION
1.添加validateKey 
2.生成时忽略validate字段
3.在swaggerOperationObject中添加Consumes参数
4.对请求的tag类型进行判断，添加对应的请求体类型。
