### PR TITLE
feat(parser.go): 添加form-data对上传文件的支持 & 添加@doc描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,26 @@ GOPROXY=https://goproxy.cn/,direct go install github.com/zeromicro/goctl-swagger
      UserSearchReq {
       KeyWord string `form:"keyWord"`
      }
+  
+     UploadReq {
+      Type int    `form:"type"`
+      Key  string `form:"key,optional"`
+     }
+     
+     UploadResp {
+      Name string `json:"name"`
+      Age int `json:"age"`
+      Birthday string `json:"birthday"`
+      Description string `json:"description"`
+      Tag []string `json:"tag"`
+     }
     )
     
+    @server(
+      // 这里是为了给service添加swagger的security，用于使用Authorize添加到接口的header
+      // 如果添加了jwt，这个描述可以省略
+      security: true
+    )
     service user-api {
      @doc(
       summary: "注册"
@@ -77,6 +95,13 @@ GOPROXY=https://goproxy.cn/,direct go install github.com/zeromicro/goctl-swagger
      )
      @handler searchUser
      get /api/user/search (UserSearchReq) returns (UserInfoReply)
+  
+     @doc(
+      summary: "上传文件，body修改为formData，并添加一个file参数"
+      inject_formdata_param: "file"
+     )
+     @handler UploadHandler
+     post /file/upload (UploadReq) returns (UploadResp)
     }
     ```
 

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1,0 +1,57 @@
+package generate
+
+import (
+	"testing"
+
+	"github.com/zeromicro/go-zero/tools/goctl/api/parser"
+	"github.com/zeromicro/go-zero/tools/goctl/plugin"
+)
+
+func TestDo(t *testing.T) {
+
+	type args struct {
+		apiFile  string
+		filename string
+		host     string
+		basePath string
+		schemes  string
+		in       *plugin.Plugin
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "",
+			args: args{
+				apiFile:  "./upload.api",
+				filename: "upload.json",
+				host:     "127.0.0.1:8890",
+				basePath: "/",
+				schemes:  "http",
+				in: &plugin.Plugin{
+					Api:         nil,
+					ApiFilePath: "./upload.api",
+					Style:       "",
+					Dir:         "./",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		// 解析api文件
+		api, err := parser.Parse(tt.args.apiFile)
+		if err != nil {
+			t.Errorf("Parse() error = %v", err)
+		}
+		tt.args.in.Api = api
+
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Do(tt.args.filename, tt.args.host, tt.args.basePath, tt.args.schemes, tt.args.in); (err != nil) != tt.wantErr {
+				t.Errorf("Do() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/generate/upload.api
+++ b/generate/upload.api
@@ -1,0 +1,28 @@
+syntax = "v1"
+
+// 上传文件
+type UploadRequest {
+	Type int    `form:"type"`         // Type 1视频 2音频 3图片 4文档 5附件
+	Key  string `form:"key,optional"` // Key 用于自定义保存到COS的文件名称，会自动加上传的文件后缀
+}
+
+type UploadResp {
+	Msg string `json:"msg"`
+	ID  string `json:"id"`
+	Src string `json:"src"`
+}
+
+// 文件
+@server (
+	middleware: Auth
+	group: api
+	security: true
+)
+service upload {
+	@doc (
+		summary : "上传文件"
+		inject_formdata_param: "file"
+	)
+	@handler UploadHandler
+	post /file/upload (UploadRequest) returns (UploadResp)
+}

--- a/generate/upload.json
+++ b/generate/upload.json
@@ -1,0 +1,116 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "host": "127.0.0.1:8890",
+  "basePath": "/",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/file/upload": {
+      "post": {
+        "summary": "上传文件",
+        "operationId": "UploadHandler",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/UploadResp"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file"
+          },
+          {
+            "name": "type",
+            "description": "// Type 1视频 2音频 3图片 4文档 5附件",
+            "in": "formData",
+            "required": true,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "key",
+            "description": "// Key 用于自定义保存到COS的文件名称，会自动加上传的文件后缀",
+            "in": "formData",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "api"
+        ],
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "security": [
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "UploadRequest": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "integer",
+          "format": "int32",
+          "description": " Type 1视频 2音频 3图片 4文档 5附件"
+        },
+        "key": {
+          "type": "string",
+          "description": " Key 用于自定义保存到COS的文件名称，会自动加上传的文件后缀"
+        }
+      },
+      "title": "UploadRequest",
+      "required": [
+        "type"
+      ]
+    },
+    "UploadResp": {
+      "type": "object",
+      "properties": {
+        "msg": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "src": {
+          "type": "string"
+        }
+      },
+      "title": "UploadResp",
+      "required": [
+        "msg",
+        "id",
+        "src"
+      ]
+    }
+  },
+  "securityDefinitions": {
+    "apiKey": {
+      "type": "apiKey",
+      "description": "Enter JWT Bearer token **_only_**",
+      "name": "Authorization",
+      "in": "header"
+    }
+  }
+}


### PR DESCRIPTION
添加form-data对上传文件的支持，使UI支持文件上传 & 添加@doc描述security: true，在没有使用框架的jwt的时候，使生成的文档附带 security: apiKey