### PR TITLE
fix: Header problem in get request

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -228,11 +228,14 @@ func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swagge
 				}
 				if strings.ToUpper(route.Method) == http.MethodGet {
 					for _, member := range defineStruct.Members {
-						if strings.Contains(member.Tag, "path") {
+						if strings.Contains(member.Tag, "path") || strings.Contains(member.Tag, "header") {
 							continue
 						}
 						if embedStruct, isEmbed := member.Type.(spec.DefineStruct); isEmbed {
 							for _, m := range embedStruct.Members {
+								if strings.Contains(m.Tag, "path") || strings.Contains(m.Tag, "header") {
+									continue
+								}
 								parameters = append(parameters, renderStruct(m))
 							}
 							continue


### PR DESCRIPTION
解决问题：https://github.com/zeromicro/goctl-swagger/issues/59

在结构中写入header或嵌套结构写入header时会出现：
api: 
```go
type (
	Headers {
		GameID  string `header:"x-client-id,optional"`
		ChainID string `header:"x-chain-id,optional"`
	}
)
```
gen swagger:
![image](https://github.com/zeromicro/goctl-swagger/assets/23273601/44199dc1-c535-491c-9140-0d796ffdb803)


期望只有：
![image](https://github.com/zeromicro/goctl-swagger/assets/23273601/9d40be5c-ec7f-466a-92b7-5c868591001b)


发现是因为没有忽略header Tag 并且 嵌套使用时不会忽略，当前已解决，希望尽快检查合并