### PR TITLE
fix: json tag column  contains 'form' words and is parsed to form-data

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -253,7 +253,7 @@ func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swagge
 
 			if defineStruct, ok := route.RequestType.(spec.DefineStruct); ok {
 				for _, member := range defineStruct.Members {
-					if strings.Contains(member.Tag, "form") {
+					if strings.Contains(member.Tag, "form:") {
 						operationObject.Consumes = []string{"multipart/form-data"}
 						break
 					}


### PR DESCRIPTION
json tag like `json:"label_format"`, it will be parsed to form-data