### PR TITLE
Fix when the json parameter of field is like %form% that is marked as…

### DIFF
--- a/generate/parser.go
+++ b/generate/parser.go
@@ -253,7 +253,8 @@ func renderServiceRoutes(service spec.Service, groups []spec.Group, paths swagge
 
 			if defineStruct, ok := route.RequestType.(spec.DefineStruct); ok {
 				for _, member := range defineStruct.Members {
-					if strings.Contains(member.Tag, "form") {
+					structTag := reflect.StructTag(member.Tag)
+					if len(structTag.Get("form")) != 0 {
 						operationObject.Consumes = []string{"multipart/form-data"}
 						break
 					}


### PR DESCRIPTION
Use strings.Contains(member.Tag, "form")
when my field is a json parameter “transform” or other like '%form%' it marks my document as a form parameter